### PR TITLE
Corrected reverse complement mistake in nucleotide context.

### DIFF
--- a/GenomeSigInfer/utils/helpers.py
+++ b/GenomeSigInfer/utils/helpers.py
@@ -79,6 +79,9 @@ TSB_REF = {
 	19: "N",
 }
 
+PURINE = ('A', 'G')
+PYRIMIDINE = ('C', 'T')
+
 # MUTATION TYPES random order
 MUTATION_TYPES = np.array(["C>G", "C>A", "C>T", "T>G", "T>C", "T>A"])
 

--- a/GenomeSigInfer/vcf/VCFMatrixGenerator.py
+++ b/GenomeSigInfer/vcf/VCFMatrixGenerator.py
@@ -51,20 +51,11 @@ def read_vcf_file(vcf_file: Path) -> pd.DataFrame:
 	with warnings.catch_warnings():
 		warnings.filterwarnings("ignore", category=pd.errors.DtypeWarning)
 		df = pd.read_csv(vcf_file, sep="\t", header=None)
-	# Change every purine mutation to a pyrimidine mutation
-	translate_purine_to_pyrimidine = {"A": "T", "G": "C"}
-	translate_nucleotide = {"A": "T", "C": "G", "G": "C", "T": "A"}
-	condition = df[8].isin(["A", "G"]) & df[9].isin(["A", "C", "G", "T"])
-	df[9] = np.where(condition, df[9].map(translate_nucleotide), df[9])
-	df[8] = df[8].map(translate_purine_to_pyrimidine).fillna(df[8])
-	mutations = np.array(df[8].astype(str) + ">" + df[9].astype(str))
 	# Extracting mutation information and filtering the dataframe
-	mutations = np.array(df[8].astype(str) + ">" + df[9].astype(str))
 	filtered_df = df[
 		((df.iloc[:, 3] == "GRCh37") | (df.iloc[:, 3] == "GRCh38"))
 		& (
-			np.isin(mutations, helpers.MUTATION_TYPES)
-			& ((df[4] == "SNP") | (df[4] == "SNV"))
+			((df[4] == "SNP") | (df[4] == "SNV"))
 		)
 	]
 	# Converting the chromosome column to string type

--- a/tests/sbs_test.py
+++ b/tests/sbs_test.py
@@ -34,33 +34,64 @@ class TestGenerateSBSMatrix(unittest.TestCase):
 
 		This test case verifies the correctness of the generated SBS matrix by performing the following assertions:
 		- The samples DataFrame is not empty.
-		- The samples DataFrame has the shape of (96, 4919).
+		- The samples DataFrame has the shape of (24576, 1+1).
 		- The count of mutations for a specific sample and mutation type matches the expected value.
 		- The count of mutations for a specific sample matches the expected value.
 		- The count of mutations for a specific sample and mutation type at a specific index matches the expected value.
 		- The context_96 variable is equal to the generated SBS matrix.
 		"""
+		context_size = 7
 		sbs_sampled_df = SBSMatrixGenerator.generate_single_sbs_matrix(
 			folder=self.folder_sbs,
 			vcf_files=self.vcf_files,
 			ref_genome=self.ref_genome,
-			genome=self.genome,
-			max_context=3,
+			max_context=context_size,
 		)
 		# Assert the samples DataFrame is not empty
 		assert not sbs_sampled_df.empty
-		# Assert the samples DataFrame has the shape of (96, 4919)
-		assert sbs_sampled_df.shape == (96, 4919)
+		# Assert the samples DataFrame has the shape of (24576, 2)
+		n_classes = 6 * 4 ** (context_size - 1)
+		assert sbs_sampled_df.shape == (n_classes, 2)
 		# Assert the count of mutations for a specific sample and mutation type
-		assert sbs_sampled_df.columns.to_list()[:2] == [
-			"MutationType",
-			"ALL::PD3952a",
-		]
+		sample = "Thy-AdenoCa::PTC-88C"
+		assert sbs_sampled_df.columns.to_list()[:2] == ["MutationType", sample]
 		# Assert the count of mutations for a specific sample
-		assert sbs_sampled_df["Thy-AdenoCa::PTC-88C"].sum() == 484
-		# Assert the count of mutations for a specific sample and mutation type
-		assert sbs_sampled_df["Thy-AdenoCa::PTC-88C"][34] == 21
-		assert self.context_96 == sbs_sampled_df
+		assert sbs_sampled_df[sample].sum() == 8
+		# Number of T>G mutations taking into account reverse complement symmetry.
+		ref_letter_loc = (context_size - 1) // 2 + 1
+		is_thymine_subst = sbs_sampled_df['MutationType'].map(
+			lambda x: x[ref_letter_loc] == 'T'
+		)
+		n_thymine_subst = sbs_sampled_df.loc[is_thymine_subst].sum(axis=0)
+		# In total: 3 (C>G) + 2 (A>G) = 5.
+		self.assertEqual(n_thymine_subst[sample], 5)
+
+		df_thy = sbs_sampled_df.set_index('MutationType')[sample]
+
+		# 1: chr2:96521744, T>C: TCC[T>C]CAT:
+		# self.assertEqual(df_thy.loc['C[T>C]C'], 1)
+		self.assertEqual(df_thy.loc['TCC[T>C]CAT'], 1)
+
+		# 2: chr4:96525794, C>A: ATG[C>A]CCT
+		self.assertEqual(df_thy.loc['ATG[C>A]CCT'], 1)
+
+		# 3: chr2:96617125, T>C: ATC[T>C]TTC
+		# 5: chr2:97817647, A>G: GAA(A>G)GAT.
+		#                      : CTT(T>C)CTA.
+		self.assertEqual(df_thy.loc['ATC[T>C]TTC'], 2)
+
+		# 4: chr2:97817617, T>C: AGA[T>C]TAT
+		self.assertEqual(df_thy.loc['AGA[T>C]TAT'], 1)
+
+		# 6: chr2:97817659, C>T: CTC[C>T]ACG.
+		self.assertEqual(df_thy.loc['CTC[C>T]ACG'], 1)
+
+		# 7: chr2:97817661, C>T: CCA[C>T]GAT.
+		self.assertEqual(df_thy.loc['CCA[C>T]GAT'], 1)
+
+		# 8: chr2:97911732, A>G: ACA(A>G)TAA
+		#                      : TGT(T>C)ATT.
+		self.assertEqual(df_thy.loc['TTA[T>C]TGT'], 1)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
In the original GenomeSigInfer implementation, only the reference letter is complemented, but not the context. This is not correct [see [BMC Genom. 20, 685 (2019)](https://doi.org/10.1186/s12864-019-6041-2)]. This pull request fixes this issue by also reverse complementing the nucleotide context.